### PR TITLE
Wenn python 2.7.x nicht installiert, wird es nachinstalliert

### DIFF
--- a/doorpi-config.sh
+++ b/doorpi-config.sh
@@ -53,6 +53,9 @@ DoorPiInstall(){
 	    python2V=true
     fi 		
 	
+	if [ -d $DoorpiSetup ]; then      
+        return result="Doorpi schon installiert, Installation wird abgebrochen"
+    fi 	
 	
 	if [ python2V ]; then 
 	    sudo apt-get -y install python-is-python2 &&
@@ -71,10 +74,6 @@ DoorPiInstall(){
 	    sudo apt-get -y install python-watchdog || return result="Watchdog installation fehlgeschlagen"
 	fi
 	
-    if [ -d $DoorpiSetup ]; then      
-        return result="Doorpi schon installiert, Installation wird abgebrochen"
-    fi    
-
     if [ -d $TempDoorpi ]; then
         echo "Verzeichnis < $TempDoorpi > schon vorhanden und wird gelöscht"
         rm -r $TempConfig

--- a/doorpi-config.sh
+++ b/doorpi-config.sh
@@ -54,8 +54,9 @@ DoorPiInstall(){
     fi 		
 	
 	if [ -d $DoorpiSetup ]; then      
-        return result="Doorpi schon installiert, Installation wird abgebrochen"
-    fi 	
+	    result="Doorpi schon installiert, Installation wird abgebrochen" 
+        return 
+	fi 	
 	
 	if [ python2V ]; then 
 	    sudo apt-get -y install python-is-python2 &&

--- a/doorpi-config.sh
+++ b/doorpi-config.sh
@@ -239,7 +239,7 @@ do
         "25" "| Daemon Stop            Beenden des Daemon"  \
         "30" "| Backup                 Doorpi Konfig backup" \
         "40" "| Restore                Wiederherstellung der Doorpi Konfig"  \
-		"50" "| Restore                Wiederherstellung der Doorpi Konfig"  \
+		"50" "| Config. Update         Git pull wird ausgeführt"  \
         "60" "| Samba                  Installation Samba" 3>&2 2>&1 1>&3	
     )
 


### PR DESCRIPTION
Im Raspberry OS ab version 30.10.21 wird kein python 2 mehr per default installiert. Script prüft ob python 2.7.x installiert ist ggf. wird es nachinstalliert